### PR TITLE
Fix indentation in config.cue

### DIFF
--- a/config.cue
+++ b/config.cue
@@ -1,8 +1,8 @@
 #Config: {
-	http: {
-	  listen_port: 8080
-	}
-	database: {
+  http: {
+    listen_port: 8080
+  }
+  database: {
     host:     !="" // must be specified and non-empty
     user:     !="" // must be specified and non-empty
     password: !="" // must be specified and non-empty


### PR DESCRIPTION
Fixes indentation of the `http` block in [main/config.cue](https://github.com/kelseyhightower/hello-cuelang/blob/main/config.cue)